### PR TITLE
removing spurious line of code from case R.id.nav_owner code block

### DIFF
--- a/app/src/main/java/com/example/idea/MainActivity.java
+++ b/app/src/main/java/com/example/idea/MainActivity.java
@@ -314,10 +314,9 @@ public class MainActivity extends AppCompatActivity implements HomeFragment.OnNe
                 toast = Toast.makeText(this,
                         "Owner Fragment", Toast.LENGTH_SHORT);
                 toast.show();
+                
                 newFragment = new OwnerFragment();
                 //remove spinner from owner fragment
-
-                newFragment = new ProfileFragment();
                 spinner.setVisibility(View.GONE);
                 break;
 


### PR DESCRIPTION
I removed a spurious line of code from the following code block from mainactivity:
case R.id.nav_owner:
               Log.i(TAG, "owner");
               toast = Toast.makeText(this,
                       "Owner Fragment", Toast.LENGTH_SHORT);
               toast.show();
               newFragment = new OwnerFragment();
               //remove spinner from owner fragment
               newFragment = new ProfileFragment();
               spinner.setVisibility(View.GONE);
               break;